### PR TITLE
Update D-30 placeable arty

### DIFF
--- a/packages/mtc-artillery/src/config/guns.ts
+++ b/packages/mtc-artillery/src/config/guns.ts
@@ -58,13 +58,18 @@ const customGuns: Record<string, Gun> = {
         explosiveMass: 1.67,
       },
       {
-        name: '3OF56',
-        velocity: 690,
+        name: '3OF56 Low Charge',
+        velocity: 175,
         explosiveMass: 3.6,
       },
       {
-        name: '3OF56 Low Charge',
-        velocity: 200,
+        name: '3OF56 Medium Charge',
+        velocity: 350,
+        explosiveMass: 3.6,
+      },
+      {
+        name: '3OF56 High Charge',
+        velocity: 690,
         explosiveMass: 3.6,
       },
     ],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added distinct 3OF56 charge variants for the D-30: Low, Medium, and High.

* **Changes**
  * Renamed existing entries to “3OF56 Low Charge” and “3OF56 Medium Charge.”
  * Updated muzzle velocities: Low 175, Medium 350, High 690.
  * Standardized explosive mass to 3.6 across all 3OF56 variants.
  * No changes to other guns or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->