### PR TITLE
add new 120mm mortar

### DIFF
--- a/packages/mtc-artillery/src/config/guns.ts
+++ b/packages/mtc-artillery/src/config/guns.ts
@@ -38,6 +38,27 @@ const customGuns: Record<string, Gun> = {
     ],
   },
 
+    M120SoltamK6: {
+    name: 'M120/Soltam K6',
+    projectiles: [
+      {
+        name: 'Medium Charge',
+        velocity: 172,
+        explosiveMass: 2,
+      },
+      {
+        name: 'Low Charge',
+        velocity: 125,
+        explosiveMass: 2,
+      },
+      {
+        name: 'High Charge',
+        velocity: 225,
+        explosiveMass: 2,
+      },
+    ],
+  },
+  
   ags17: {
     name: 'AGS-17',
     projectiles: [

--- a/packages/mtc-artillery/src/config/guns.ts
+++ b/packages/mtc-artillery/src/config/guns.ts
@@ -44,17 +44,17 @@ const customGuns: Record<string, Gun> = {
       {
         name: 'Medium Charge',
         velocity: 172,
-        explosiveMass: 14,
+        explosiveMass: 3.29,
       },
       {
         name: 'Low Charge',
         velocity: 125,
-        explosiveMass: 14,
+        explosiveMass: 3.29,
       },
       {
         name: 'High Charge',
         velocity: 225,
-        explosiveMass: 14,
+        explosiveMass: 3.29,
       },
     ],
   },

--- a/packages/mtc-artillery/src/config/guns.ts
+++ b/packages/mtc-artillery/src/config/guns.ts
@@ -58,7 +58,7 @@ const customGuns: Record<string, Gun> = {
       },
       {
         name: 'M68 Medium Charge',
-        velocity: 225,
+        velocity: 172,
         explosiveMass: 0.08,
       },
       {
@@ -68,7 +68,7 @@ const customGuns: Record<string, Gun> = {
       },
       {
         name: 'M68 Low Charge',
-        velocity: 225,
+        velocity: 125,
         explosiveMass: 0.08,
       },
     ],

--- a/packages/mtc-artillery/src/config/guns.ts
+++ b/packages/mtc-artillery/src/config/guns.ts
@@ -52,7 +52,7 @@ const customGuns: Record<string, Gun> = {
         explosiveMass: 3.29,
       },
       {
-        name: 'M934A1High Charge',
+        name: 'M934A1 High Charge',
         velocity: 225,
         explosiveMass: 3.29,
       },

--- a/packages/mtc-artillery/src/config/guns.ts
+++ b/packages/mtc-artillery/src/config/guns.ts
@@ -66,7 +66,7 @@ const customGuns: Record<string, Gun> = {
         velocity: 225,
         explosiveMass: 0.08,
       },
-     {
+      {
         name: 'M68 Low Charge',
         velocity: 225,
         explosiveMass: 0.08,

--- a/packages/mtc-artillery/src/config/guns.ts
+++ b/packages/mtc-artillery/src/config/guns.ts
@@ -38,23 +38,23 @@ const customGuns: Record<string, Gun> = {
     ],
   },
 
-    M120SoltamK6: {
+  M120SoltamK6: {
     name: 'M120/Soltam K6',
     projectiles: [
       {
         name: 'Medium Charge',
         velocity: 172,
-        explosiveMass: 2,
+        explosiveMass: 14,
       },
       {
         name: 'Low Charge',
         velocity: 125,
-        explosiveMass: 2,
+        explosiveMass: 14,
       },
       {
         name: 'High Charge',
         velocity: 225,
-        explosiveMass: 2,
+        explosiveMass: 14,
       },
     ],
   },

--- a/packages/mtc-artillery/src/config/guns.ts
+++ b/packages/mtc-artillery/src/config/guns.ts
@@ -42,19 +42,34 @@ const customGuns: Record<string, Gun> = {
     name: 'M120/Soltam K6',
     projectiles: [
       {
-        name: 'Medium Charge',
+        name: 'M934A1 Medium Charge',
         velocity: 172,
         explosiveMass: 3.29,
       },
       {
-        name: 'Low Charge',
+        name: 'M934A1 Low Charge',
         velocity: 125,
         explosiveMass: 3.29,
       },
       {
-        name: 'High Charge',
+        name: 'M934A1High Charge',
         velocity: 225,
         explosiveMass: 3.29,
+      },
+      {
+        name: 'M68 Medium Charge',
+        velocity: 225,
+        explosiveMass: 0.08,
+      },
+      {
+        name: 'M68 High Charge',
+        velocity: 225,
+        explosiveMass: 0.08,
+      },
+     {
+        name: 'M68 Low Charge',
+        velocity: 225,
+        explosiveMass: 0.08,
       },
     ],
   },


### PR DESCRIPTION
hi add new mortar(120mm Soltam) K6 for the modern green engineer 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the M120/Soltam K6 mortar with six ammunition options: M934A1 (Low/Medium/High charges — velocities ~125/172/225, high explosive mass ~3.29) and M68 (Low/Medium/High — velocity ~225, lower explosive mass ~0.08), expanding tactical range and effect choices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->