### PR TITLE
feat(i18n): add French locale fr-FR

### DIFF
--- a/packages/mtc-artillery/src/i18n/common.json
+++ b/packages/mtc-artillery/src/i18n/common.json
@@ -3,12 +3,12 @@
     "de-DE": "Deutsch",
     "en-US": "English",
     "es-ES": "Español",
+    "fr-FR": "Français",
     "nl-NL": "Nederlands",
     "pl-PL": "Polski",
     "ru-RU": "Русский",
     "th-TH": "ภาษาไทย",
     "uk-UA": "українська",
-    "vi-VN": "Tiếng Việt",
-    "fr-FR": "French"
+    "vi-VN": "Tiếng Việt"
   }
 }

--- a/packages/mtc-artillery/src/i18n/common.json
+++ b/packages/mtc-artillery/src/i18n/common.json
@@ -8,6 +8,7 @@
     "ru-RU": "Русский",
     "th-TH": "ภาษาไทย",
     "uk-UA": "українська",
-    "vi-VN": "Tiếng Việt"
+    "vi-VN": "Tiếng Việt",
+    "fr-FR": "French"
   }
 }

--- a/packages/mtc-artillery/src/i18n/config.json
+++ b/packages/mtc-artillery/src/i18n/config.json
@@ -3,6 +3,7 @@
     "de-DE",
     "en-US",
     "es-ES",
+    "fr-FR",
     "nl-NL",
     "pl-PL",
     "ru-RU",

--- a/packages/mtc-artillery/src/i18n/index.ts
+++ b/packages/mtc-artillery/src/i18n/index.ts
@@ -5,6 +5,7 @@ import config from './config.json';
 import deDE from '@/i18n/locales/de-DE.json';
 import enUS from '@/i18n/locales/en-US.json';
 import esES from '@/i18n/locales/es-ES.json';
+import frFR from '@/i18n/locales/fr-FR.json';
 import nlNL from '@/i18n/locales/nl-NL.json';
 import plPL from '@/i18n/locales/pl-PL.json';
 import ruRU from '@/i18n/locales/ru-RU.json';
@@ -18,6 +19,7 @@ const locales: Record<string, LocaleDictionary> = {
   'de-DE': deDE,
   'en-US': enUS,
   'es-ES': esES,
+  'fr-FR': frFR,
   'nl-NL': nlNL,
   'pl-PL': plPL,
   'ru-RU': ruRU,

--- a/packages/mtc-artillery/src/i18n/locales/fr-FR.json
+++ b/packages/mtc-artillery/src/i18n/locales/fr-FR.json
@@ -1,0 +1,30 @@
+{
+  "meta": {
+    "description": "Un calculateur d'artillerie conçu pour Multicrew Tank Combat sur Roblox."
+  },
+  "typography": {
+    "azimuth": "Azimut",
+    "distance": "Distance",
+    "downloadOverlay": "Téléchargez l'overlay en jeu sur <link></link>.",
+    "elevation": "Élévation",
+    "gun": "canon",
+    "heightmap": "Cette carte propose une carte de hauteur pour une meilleure précision",
+    "instructions": "<kbd>LMB</kbd> pour définir votre position. <kbd>RMB</kbd> pour définir la position de la cible. Maintenez <kbd>MMB</kbd> pour déplacer la carte, et utilisez la molette pour zoomer.",
+    "map": "Carte",
+    "metersPerSecond": "{value} m/s",
+    "notApplicable": "N/A",
+    "or": "ou",
+    "projectile": "Projectile",
+    "settings": {
+      "legacyBlastRadius": "Rayon d'explosion hérité"
+    },
+    "status": "Statut",
+    "switchSelectionTo": "Passer la sélection sur {value}",
+    "target": "cible",
+    "timeOfFlight": "Temps de vol"
+  },
+  "units": {
+    "meter": "{value, plural, =1 {{value} mètre} other {{value} mètres}}",
+    "second": "{value, plural, =1 {{value} seconde} other {{value} secondes}}"
+  }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added French (`fr-FR`) as an available language in the application.
  * Provides complete French UI text for the artillery calculator, including instructions, status/selection wording, and localized pluralized units for meters and seconds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->